### PR TITLE
キャプションの前の半行アキは不要です #42

### DIFF
--- a/t/30_indesign_basic_syntax.t
+++ b/t/30_indesign_basic_syntax.t
@@ -250,7 +250,6 @@ __END__
 <ParaStyle:箇条書き><cTypeface:B><cFont:A-OTF ゴシックMB101 Pro><cotfcalt:0><cotfl:nalt,7>1<cTypeface:><cFont:><cotfcalt:><cotfl:>hogehogeをします
 <ParaStyle:箇条書き><cTypeface:B><cFont:A-OTF ゴシックMB101 Pro><cotfcalt:0><cotfl:nalt,7>2<cTypeface:><cFont:><cotfcalt:><cotfl:>fugafugaと<cTypeface:B><cFont:A-OTF ゴシックMB101 Pro><cotfcalt:0><cotfl:nalt,7>1<cTypeface:><cFont:><cotfcalt:><cotfl:>の結果を足し合わせます
 <ParaStyle:本文>　リスト1.1<CharStyle:丸文字><2460><CharStyle:>ではアラートを出しています。<CharStyle:丸文字><2461><CharStyle:>でもアラートを出しています。(a1)エスケープできます。
-<ParaStyle:半行アキ>
 <ParaStyle:キャプション>リスト1.1	キャプション（コードのタイトル）
 <ParaStyle:リスト>function hoge() {
 <ParaStyle:リスト>    alert(foo);　… <CharStyle:丸文字><2460><CharStyle:>
@@ -299,7 +298,6 @@ __END__
     ●リスト1.1::キャプション
     use strict;
 --- expected
-<ParaStyle:半行アキ>
 <ParaStyle:キャプション>リスト1.1	キャプション
 <ParaStyle:リスト>use strict;
 
@@ -324,7 +322,6 @@ __END__
         alert(b);
     }
 --- expected
-<ParaStyle:半行アキ>
 <ParaStyle:キャプション>図1.1	キャプション（コマンドのタイトル）
 <ParaStyle:リスト白文字>$ command  <CharStyle:コマンド太字>foo<CharStyle:> // コマンド内強調
 <ParaStyle:リスト白文字>bar <CharStyle:リストコメント白地黒文字> こんな風にコメントがつけられます <CharStyle:>


### PR DESCRIPTION
キャプション付きの図やリストは別ボックスになりますので
