### PR TITLE
Fix for newer Encode module(>= 2.53)

### DIFF
--- a/lib/Text/Md2Inao/Util.pm
+++ b/lib/Text/Md2Inao/Util.pm
@@ -41,7 +41,7 @@ sub to_list_style {
 # 文字幅計算
 # http://d.hatena.ne.jp/tokuhirom/20070514/1179108961
 sub visual_length {
-    local $_ = Encode::decode_utf8(shift);
+    local $_ = shift;
     my $ret = 0;
     while (/(?:(\p{InFullwidth}+)|(\p{InHalfwidth}+))/g) { $ret += ($1 ? length($1)*2 : length($2)) }
     return $ret;


### PR DESCRIPTION
In newer Encode, we cannot pass decoded string to decode methods
such as `decoded_utf8` and we get error if we pass decoded string.
Some tests are failed with newer Encode because of this(Log is [here](https://gist.github.com/syohex/9321248))

I suppose that `visual_length` must take string(not octets) if user
uses `bin/md2inao.pl` so we need not to decode argument of `visual_length`.
