### PR TITLE
Howdownに変えたことでHTMLを混ぜたときの空白の扱いが微妙にかわったことについて

### DIFF
--- a/t/15_mixed_html_tag.t
+++ b/t/15_mixed_html_tag.t
@@ -1,0 +1,28 @@
+use utf8;
+use Test::Base;
+use Text::Md2Inao::TestHelper;
+
+plan tests => 1 * blocks;
+run_is in => 'expected';
+
+__END__
+=== multi-line HTML tags
+--- in md2inao
+foo
+bar
+<div class="undefined">baz</div>
+--- expected
+foobar<div class="undefined">baz</div>
+
+=== multi-line HTML tags with empty lines
+--- in md2inao
+foo
+
+bar
+
+<div class="undefined">baz</div>
+--- expected chomp
+foo
+bar
+<div class="undefined">baz</div>
+


### PR DESCRIPTION
#68 のコメントの返信です。

c46205d3641d54a8dd7017ce418ca88cb72976cf で一箇所テストを変えていますが、それはhoedownにしたら微妙に空白の扱いが変わったからなのでした。本来テストしたかったこと（divと未知のclassの組み合わせ）とは関係ないのでまあいいかーと思ったのですが、挙動はかわるのでよくなかったですね！

変わったところ:
- 地の文(markdown)の直後に`<div>...</div>`が続いた時、地の文と空行の間のスペースが取り除かれる（Text::Markdownのときは空行が残ったままになる）

md2inao的には foo\nbar が foobar に変換される仕様なので、こっちのほうが正しいような気もしますし、記述言語（コンテキスト）が変わる以上空行が残るべきという気もします。編集的にはどういう挙動が望ましいですかね？ (cc: @inao )
