### PR TITLE
コードブロック中のキーボードフォントに変換されない

### DIFF
--- a/lib/Text/Md2Inao/Builder/InDesign.pm
+++ b/lib/Text/Md2Inao/Builder/InDesign.pm
@@ -337,6 +337,10 @@ case pre => sub {
 
     my $code = $h->find('code');
     my $text = $code ? $code->as_text : '';
+
+    # <kbd>を一旦退避する (#88)
+    $text =~ s!<(/?)kbd>!◆${1}kbd◆!g;
+
     $text = escape_html($text);
 
     my $list_label = 'リスト';
@@ -377,6 +381,8 @@ case pre => sub {
 
     # コード内イタリック
     $text =~ s!\___(.+?)\___!<CharStyle:イタリック（変形斜体）>$1<CharStyle:>!g;
+    # コード内キーボードフォント https://github.com/naoya/md2inao/pull/88
+    $text =~ s!◆kbd◆(.+?)◆/kbd◆!<cFont:KeyMother>$1<cFont:>!g;
 
     chomp $text;
 

--- a/t/32_indesign_free_replacer.t
+++ b/t/32_indesign_free_replacer.t
@@ -35,6 +35,7 @@ __END__
 --- in md2inao
     <kbd>R</kbd>
 --- expected
+<ParaStyle:半行アキ>
 <ParaStyle:リスト><cFont:KeyMother>R<cFont:>
 
 === right arrow


### PR DESCRIPTION
Vol.80の作業時に発見しましたのでご報告させてください。

コミットしたテストのようになってほしいのですが、現状は以下のように変換されます。

```
<ParaStyle:リスト><005C><kbd<005C>>R<005C></kbd<005C>>
```
