### PR TITLE
Shiftキーが連続すると、うまく変換されないの受け入れテスト

### DIFF
--- a/config/id_filter.json
+++ b/config/id_filter.json
@@ -64,6 +64,8 @@
         "✖" : "<ct:Regular><cf:Zapf Dingbats><2716><ct:><cf:>",
         "\\" : "<005C><005C>",
         "~" : "<007E>",
-        "～" : "<301C>"
+        "～" : "<301C>",
+        
+        "<cFont:KeyMother>Shift<cFont:>" : "<cFont:Key Snd Mother>`<cFont:>",
     }
 }

--- a/t/32_indesign_free_replacer.t
+++ b/t/32_indesign_free_replacer.t
@@ -184,6 +184,12 @@ __END__
 
 === kbd
 --- in md2inao
+<kbd>Shift</kbd><kbd>Shift</kbd>
+--- expected
+<ParaStyle:本文><cFont:Key Snd Mother>`<cFont:><cFont:Key Snd Mother>`<cFont:>
+
+=== kbd
+--- in md2inao
 <kbd>Tab</kbd>
 --- expected
 <ParaStyle:本文><cFont:Key Snd Mother>k<cFont:>


### PR DESCRIPTION
さきほど @gfx さんの章で発生しました。

Shiftキーが連続する＝変換後のInDesignテキストにバッククォートが2つ登場するなのですが、現状ですと以下のように、`コマンド`の扱いになってしまうようです。

```
<ParaStyle:本文><cFont:Key Snd Mother><CharStyle:コマンド><cFont:><cFont:Key Snd Mother><CharStyle:><cFont:>
```