### PR TITLE
リンク記法で%エンコーディングをさせない受け入れテスト

### DIFF
--- a/t/30_indesign_basic_syntax.t
+++ b/t/30_indesign_basic_syntax.t
@@ -529,3 +529,8 @@ World
 <ParaStyle:区切り線>
 <ParaStyle:本文>World
 
+=== no % encoding
+--- in md2inao
+[SynCha](http://あいうえお)
+--- expected
+<ParaStyle:本文>SynCha<cstyle:上付き><fnStart:><pstyle:注釈>http://あいうえお<fnEnd:><cstyle:>


### PR DESCRIPTION
紙面で以下ですと読者の方が入力できませんので、

`http://ja.wikipedia.org/wiki/%E3%82%A6%E3%82%A3%E3%82%AD%E3%83%9A%E3%83%87%E3%82%A3%E3%82%A2`

以下のように%エンコーディングをさせないURLを掲載したいです。

`http://ja.wikipedia.org/wiki/ウィキペディア`

現状のリンク記法では%エンコーディングされますので、させなくさせていただきたいです。
そのための受け入れテストを追加しました。

なお、%エンコーディングされても誤りにはなりませんし、`(注:)`を使うことで回避も可能ですのでラベルはlowとさせていただきました。
