### PR TITLE
表のキャプションに「表1::」などがない場合、キャプションがlinuxになる件の受け入れテスト

### DIFF
--- a/t/30_indesign_basic_syntax.t
+++ b/t/30_indesign_basic_syntax.t
@@ -517,6 +517,28 @@ function bar(b) {
 <ParaStyle:表>内容1	内容2
 <ParaStyle:表>内容1	内容2
 
+=== table
+--- in md2inao
+<table summary='キャプション（表のタイトル）'>
+    <tr>
+        <th>表タイトル1</th>
+        <th>表タイトル2</th>
+    </tr>
+    <tr>
+        <td>内容1</td>
+        <td>内容2</td>
+    </tr>
+    <tr>
+        <td>内容1</td>
+        <td>内容2</td>
+    </tr>
+</table>
+--- expected
+<ParaStyle:キャプション>キャプション（表のタイトル）
+<ParaStyle:表見出し行>表タイトル1	表タイトル2
+<ParaStyle:表>内容1	内容2
+<ParaStyle:表>内容1	内容2
+
 === horizontal rule
 --- in md2inao
 Hello


### PR DESCRIPTION
表のキャプションに「表1::」などがない場合、なぜかキャプションが「linux」になるようです。

期待する動作を受け入れテストにして追加させていただきました。

現状の動作は以下です。

```
--- in md2inao
<table summary='キャプション（表のタイトル）'>
    <tr>
        <th>表タイトル1</th>
        <th>表タイトル2</th>
    </tr>
    <tr>
        <td>内容1</td>
        <td>内容2</td>
    </tr>
    <tr>
        <td>内容1</td>
        <td>内容2</td>
    </tr>
</table>
--- expected
<ParaStyle:キャプション>linux
<ParaStyle:表見出し行>表タイトル1 表タイトル2
<ParaStyle:表>内容1  内容2
<ParaStyle:表>内容1  内容2
```

見逃した場合は訂正情報を出す必要がございますのでラベルは「high」とさせていただきました。
#23 の件と同時に解決していただくのがよいかもです。
