### PR TITLE
インライン数式中にバックスラッシュが存在する場合の不具合修正

### DIFF
--- a/lib/Text/Md2Inao/Builder.pm
+++ b/lib/Text/Md2Inao/Builder.pm
@@ -51,16 +51,21 @@ sub before_filter {
       ### 目印で置き換えて after_filter で戻す
 
       my @math_table = ();
+
       ## ブロック数式
       $in =~ s{(\$\$(?:[^\$]|\\\$)+\$\$)}{
         push @math_table, $1;
         "◆数式:D-$#math_table◆";
       }xegm;
+
       ## インライン数式
-      $in =~ s{(\$(?:[^\$$ ]|\\\$)+\$)}{
+      my @lines = split /\n/, $in;
+      s{(\$(?:[^\$]|\\\$)+\$)}{
         push @math_table, $1;
         "◆数式:I-$#math_table◆";
-      }xeg;
+      }xeg foreach @lines;
+      $in = join "\n", @lines;
+
       $self->math_table(\@math_table);
     }
     if (my $config = $self->before_filter_config) {


### PR DESCRIPTION
#108 には、インライン数式中にバックスラッシュが存在している場合に対応できていませんでした。
行単位で処理するよう書き換えることで、この問題を解決しています。

ですが、Perl に慣れていないため、見苦しいコードになっている可能性があります。
その場合は申し分けありませんが、良い書き方を教えていただけると嬉しいです。

よろしくお願いします。