### PR TITLE
å（U+00E5）に対応した

### DIFF
--- a/config/id_filter.json
+++ b/config/id_filter.json
@@ -127,7 +127,8 @@
         "ø" : "<00F8>",
         "ß" : "<00DF>",
         "þ" : "<00FE>",
-        
+        "å" : "<00E5>",
+
         "✓" : "<ct:Regular><cf:Zapf Dingbats><2713><ct:><cf:>",
         "✖" : "<ct:Regular><cf:Zapf Dingbats><2716><ct:><cf:>",
         "\\" : "<005C><005C>",

--- a/t/32_indesign_free_replacer.t
+++ b/t/32_indesign_free_replacer.t
@@ -344,6 +344,8 @@ my_app
 ß
 
 þ
+
+å
 --- expected
 <ParaStyle:本文><00C1>
 <ParaStyle:本文><00C9>
@@ -406,6 +408,7 @@ my_app
 <ParaStyle:本文><00F8>
 <ParaStyle:本文><00DF>
 <ParaStyle:本文><00FE>
+<ParaStyle:本文><00E5>
 
 === right-pointing double angle quotation mark
 --- in md2inao


### PR DESCRIPTION
å（U+00E5）に対応しました。
自由置換なので、テストがパスしたらマージします。