### PR TITLE
#120 のPHP Markdown Extra footnote記法に対応

### DIFF
--- a/lib/Text/Md2Inao.pm
+++ b/lib/Text/Md2Inao.pm
@@ -91,7 +91,7 @@ sub replace_markdown_extra_footnote {
 
     ## 脚注をreplace
     for (@lines) {
-        if (m/\[\^(\w+)\]/) {
+        while (m/\[\^(\w+)\]/g) {
             my ($k) = ($1);
             my $v = $footnotes{lc $k};
             if ($v) {

--- a/t/07_footnote.t
+++ b/t/07_footnote.t
@@ -1,0 +1,23 @@
+use utf8;
+use Test::Base;
+use Text::Md2Inao::TestHelper;
+
+plan tests => 1 * blocks;
+run_is in => 'expected';
+
+__END__
+=== PHP Markdown Extra style footnote
+--- in md2inao
+通常の本文[^1]通常の本文
+
+[^1]: 注釈ですよ。_イタリック_
+--- expected
+通常の本文◆注/◆注釈ですよ。◆i/◆イタリック◆/i◆◆/注◆通常の本文
+
+===
+--- in md2inao
+通常の本文[^1]通常の本文
+
+[^1]: 注釈ですよ。
+--- expected
+通常の本文◆注/◆注釈ですよ。◆/注◆通常の本文

--- a/t/07_footnote.t
+++ b/t/07_footnote.t
@@ -23,6 +23,15 @@ __END__
 通常の本文◆注/◆注釈ですよ。◆/注◆通常の本文
 
 ===
+--- in md2inao
+通常の本文1[^1]通常の本文2[^2]通常の本文3
+
+[^1]: 注釈ですよ。
+[^2]: 注釈その2ですよ。
+--- expected
+通常の本文1◆注/◆注釈ですよ。◆/注◆通常の本文2◆注/◆注釈その2ですよ。◆/注◆通常の本文3
+
+===
 --- in md2id
 通常の本文[^1]通常の本文
 
@@ -39,3 +48,12 @@ __END__
 --- expected
 <SJIS-MAC>
 <ParaStyle:本文>通常の本文<cstyle:上付き><fnStart:><pstyle:注釈>注釈ですよ。<fnEnd:><cstyle:>通常の本文
+===
+--- in md2id
+通常の本文1[^1]通常の本文2[^2]通常の本文3
+
+[^1]: 注釈ですよ。
+[^2]: 注釈その2ですよ。
+--- expected
+<SJIS-MAC>
+<ParaStyle:本文>通常の本文1<cstyle:上付き><fnStart:><pstyle:注釈>注釈ですよ。<fnEnd:><cstyle:>通常の本文2<cstyle:上付き><fnStart:><pstyle:注釈>注釈その2ですよ。<fnEnd:><cstyle:>通常の本文3

--- a/t/07_footnote.t
+++ b/t/07_footnote.t
@@ -21,3 +21,21 @@ __END__
 [^1]: 注釈ですよ。
 --- expected
 通常の本文◆注/◆注釈ですよ。◆/注◆通常の本文
+
+===
+--- in md2id
+通常の本文[^1]通常の本文
+
+[^1]: 注釈ですよ。_イタリック_
+--- expected
+<SJIS-MAC>
+<ParaStyle:本文>通常の本文<cstyle:上付き><fnStart:><pstyle:注釈>注釈ですよ。<CharStyle:イタリック（変形斜体）>イタリック<CharStyle:><fnEnd:><cstyle:>通常の本文
+
+===
+--- in md2id
+通常の本文[^1]通常の本文
+
+[^1]: 注釈ですよ。
+--- expected
+<SJIS-MAC>
+<ParaStyle:本文>通常の本文<cstyle:上付き><fnStart:><pstyle:注釈>注釈ですよ。<fnEnd:><cstyle:>通常の本文


### PR DESCRIPTION
#120 に対応してみました。

Text::Markdown::Hoedownは`HOEDOWN_EXT_FOOTNOTES`オプションでfootnote記法をサポートしているようですが、これは脚注番号と脚注本体を分離して出力するタイプであり、本文中への埋め込みは難しそうだったため、自力で対応しています。

対応する脚注がない場合はエラーにしておいた方がよいかと思うのですが、Perlは久しぶりすぎてよく分からないので警告のみにしてあります（どう書くのがよいんでしょうか…？）。