### PR TITLE
シンタックスハイライトの言語指定をもとに、!!! cmdを自動で付加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,6 @@ GitHub Flavored Markdownの[Fenced code blocks](https://docs.github.com/ja/githu
         $ command
         bar (注:こんな風にコメントがつけられます)
 
-こちらはWEB+DB PRESSなどでも使います。
-
 ### 図の画像
 
 以下の両記法に対応していますが、同一原稿では、どちらかで統一していただきたいです。

--- a/README.md
+++ b/README.md
@@ -290,18 +290,19 @@ GitHub Flavored Markdownの[Fenced code blocks](https://docs.github.com/ja/githu
 
 #### 本文中のコマンドブロック
 
-上述した「本文中のコードブロック」の記述に加え、先頭行に`!!! cmd`と書くか、GitHub Flavored MarkdownのFenced code blocks記法でシェル系の言語（[Shell系](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L5606-L5609)、[ShellSession系](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L5689-L5691)、[PowerShell系](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L4601-L4603)）を指定すると、コマンドラインっぽく黒地に白文字になります。
+上述した「本文中のコードブロック」の記述に加え、先頭行に`!!! cmd`と書いてください。  
+紙面では、コマンドラインっぽく黒地に白文字になります。
 
         !!! cmd
         $ command
         bar
 
+GitHub Flavored MarkdownのFenced code blocks記法の場合は、シェル系の言語（[Shell系](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L5606-L5609)、[ShellSession系](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L5689-L5691)、[PowerShell系](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L4601-L4603)）を指定するだけで同様の挙動になります。
+
     ```bash
     $ command
     bar
     ```
-
-コマンド行の行頭には、上記のようにプロンプト（$など）を書いてください。
 
 この場合の`(注:)`は、逆に白地に黒文字となります。
 
@@ -309,6 +310,8 @@ GitHub Flavored Markdownの[Fenced code blocks](https://docs.github.com/ja/githu
         (注:見出し的に使う)
         $ command
         bar (注:こんな風にコメントがつけられます)
+
+なお、コマンド行の行頭には、上記のようにプロンプト（$など）を書いてください。
 
 #### 別ボックスのコードブロック（リスト）
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Markdown の説明つき箇条書きには対応していないので、HTML で
             alert(b);
         }
 
-GitHub Flavored Markdown のFenced code blocks記法にも対応しています。
+GitHub Flavored Markdownの[Fenced code blocks](https://docs.github.com/ja/github/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)記法にも対応しています。
 
     ```
     function bar(b) {
@@ -290,7 +290,18 @@ GitHub Flavored Markdown のFenced code blocks記法にも対応しています�
 
 #### 本文中のコマンドブロック
 
-先頭行を`!!! cmd`とすると、コマンドラインっぽく黒地に白文字になります。
+上述した「本文中のコードブロック」の記述に加え、先頭行に`!!! cmd`と書くか、GitHub Flavored MarkdownのFenced code blocks記法でシェル系の言語（[Shell系](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L5606-L5609)、[ShellSession系](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L5689-L5691)、[PowerShell系](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L4601-L4603)）を指定すると、コマンドラインっぽく黒地に白文字になります。
+
+        !!! cmd
+        $ command
+        bar
+
+    ```bash
+    $ command
+    bar
+    ```
+
+コマンド行の行頭には、上記のようにプロンプト（$など）を書いてください。
 
 この場合の`(注:)`は、逆に白地に黒文字となります。
 
@@ -299,11 +310,9 @@ GitHub Flavored Markdown のFenced code blocks記法にも対応しています�
         $ command
         bar (注:こんな風にコメントがつけられます)
 
-コマンド行の行頭には、上記のようにプロンプト（$など）を書いてください。
-
 #### 別ボックスのコードブロック（リスト）
 
-別ボックスの「リスト」として掲載するコードには、先頭行に`●リスト1::キャプション`を書いてください。
+別ボックスの「リスト」として掲載するコードには、上述した「本文中のコードブロック」の記述に加え、冒頭に`●リスト1::キャプション`を書いてください。
 
         ●リスト1::キャプション
         (注:見出し的に使う)
@@ -313,15 +322,13 @@ GitHub Flavored Markdown のFenced code blocks記法にも対応しています�
 
 #### 別ボックスのコマンドブロック（図）
 
-別ボックスの「図」として掲載するコマンドには、先頭行に`!!! cmd`と`●図1::キャプション`を書いてください。
+別ボックスの「図」として掲載するコマンドには、上述した「本文中のコマンドブロック」の記述に加え、冒頭に`●図1::キャプション`を書いてください。
 
         !!! cmd
         ●図1::キャプション`
         (注:見出し的に使う)
         $ command
         bar (注:こんな風にコメントがつけられます)
-
-コマンド行の行頭には、上記のようにプロンプト（$など）を書いてください。
 
 こちらはWEB+DB PRESSなどでも使います。
 
@@ -564,7 +571,8 @@ Authors
 * @suzuki
 * @gfx : Release to CPAN
 * @mrkn
-
+* @matobaa
+ 
 LICENSE
 ----------
 

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -1,13 +1,5 @@
 # carton snapshot format: version 1.0
 DISTRIBUTIONS
-  Algorithm-Diff-1.1902
-    pathname: T/TY/TYEMQ/Algorithm-Diff-1.1902.tar.gz
-    provides:
-      Algorithm::Diff 1.1902
-      Algorithm::Diff::_impl 1.1902
-      Algorithm::DiffOld 1.1
-    requirements:
-      ExtUtils::MakeMaker 0
   Apache-LogFormat-Compiler-0.30
     pathname: K/KA/KAZEBURO/Apache-LogFormat-Compiler-0.30.tar.gz
     provides:
@@ -40,64 +32,6 @@ DISTRIBUTIONS
       File::Spec 0.80
       Test::More 0.47
       perl 5.006
-  Class-Load-0.20
-    pathname: D/DR/DROLSKY/Class-Load-0.20.tar.gz
-    provides:
-      Class::Load 0.20
-      Class::Load::Error::DieAfterBeginIsa undef
-      Class::Load::Error::DieAfterIsa undef
-      Class::Load::Error::SyntaxErrorAfterIsa undef
-      Class::Load::OK undef
-      Class::Load::PP 0.20
-      Class::Load::Stash undef
-      Class::Load::Stash::Sub undef
-      Class::Load::SyntaxError undef
-      Class::Load::VersionCheck 42
-      Class::Load::VersionCheck2 42
-    requirements:
-      Carp 0
-      Data::OptList 0
-      Exporter 0
-      ExtUtils::MakeMaker 6.30
-      Module::Implementation 0.04
-      Module::Runtime 0.012
-      Package::Stash 0.14
-      Scalar::Util 0
-      Test::Fatal 0
-      Test::More 0.88
-      Test::Requires 0
-      Try::Tiny 0
-      base 0
-      constant 0
-      strict 0
-      version 0
-      warnings 0
-  Class-Load-XS-0.06
-    pathname: D/DR/DROLSKY/Class-Load-XS-0.06.tar.gz
-    provides:
-      Class::Load::Error::DieAfterBeginIsa undef
-      Class::Load::Error::DieAfterIsa undef
-      Class::Load::Error::SyntaxErrorAfterIsa undef
-      Class::Load::OK undef
-      Class::Load::Stash undef
-      Class::Load::Stash::Sub undef
-      Class::Load::SyntaxError undef
-      Class::Load::VersionCheck 42
-      Class::Load::VersionCheck2 42
-      Class::Load::XS 0.06
-    requirements:
-      Class::Load 0.20
-      ExtUtils::CBuilder 0
-      Module::Build 0.3601
-      Module::Implementation 0.04
-      Test::Fatal 0
-      Test::More 0.88
-      Test::Requires 0
-      XSLoader 0
-      constant 0
-      strict 0
-      version 0
-      warnings 0
   Data-Dump-1.22
     pathname: G/GA/GAAS/Data-Dump-1.22.tar.gz
     provides:
@@ -112,16 +46,6 @@ DISTRIBUTIONS
       Symbol 0
       Test 0
       perl 5.006
-  Data-OptList-0.107
-    pathname: R/RJ/RJBS/Data-OptList-0.107.tar.gz
-    provides:
-      Data::OptList 0.107
-    requirements:
-      ExtUtils::MakeMaker 6.30
-      List::Util 0
-      Params::Util 0
-      Sub::Install 0.921
-      Test::More 0.96
   Devel-Cover-1.01
     pathname: P/PJ/PJCJ/Devel-Cover-1.01.tar.gz
     provides:
@@ -176,15 +100,6 @@ DISTRIBUTIONS
       Storable 0
       Test::More 0
       Test::Warn 0
-  Devel-GlobalDestruction-0.11
-    pathname: H/HA/HAARG/Devel-GlobalDestruction-0.11.tar.gz
-    provides:
-      Devel::GlobalDestruction 0.11
-    requirements:
-      ExtUtils::CBuilder 0.27
-      ExtUtils::MakeMaker 0
-      Sub::Exporter::Progressive 0.001006
-      perl 5.006
   Devel-Hide-0.0009
     pathname: F/FE/FERREIRA/Devel-Hide-0.0009.tar.gz
     provides:
@@ -214,35 +129,6 @@ DISTRIBUTIONS
       Filter::Util::Call 0
       Test::More 0
       perl 5.008001
-  Dist-CheckConflicts-0.02
-    pathname: D/DO/DOY/Dist-CheckConflicts-0.02.tar.gz
-    provides:
-      Bar 0.02
-      Bar::Conflicts undef
-      Bar::Conflicts2 undef
-      Bar::Conflicts3 undef
-      Bar::Conflicts::Bad undef
-      Bar::Conflicts::Bad2 undef
-      Bar::Conflicts::Bad3 undef
-      Bar::Conflicts::Good undef
-      Bar::Conflicts::Good2 undef
-      Bar::Conflicts::Good3 undef
-      Bar::Three 0.02
-      Bar::Two 0.02
-      Dist::CheckConflicts 0.02
-      Foo 0.02
-      Foo::Conflicts undef
-      Foo::Conflicts2 undef
-      Foo::Conflicts::Bad undef
-      Foo::Conflicts::Good undef
-      Foo::Three 0.02
-      Foo::Two 0.02
-    requirements:
-      ExtUtils::MakeMaker 6.31
-      List::MoreUtils 0.12
-      Sub::Exporter 0
-      Test::Fatal 0
-      Test::More 0.88
   Encode-Locale-1.03
     pathname: G/GA/GAAS/Encode-Locale-1.03.tar.gz
     provides:
@@ -253,18 +139,6 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test 0
       perl 5.008
-  Eval-Closure-0.08
-    pathname: D/DO/DOY/Eval-Closure-0.08.tar.gz
-    provides:
-      Eval::Closure 0.08
-    requirements:
-      ExtUtils::MakeMaker 6.30
-      Scalar::Util 0
-      Sub::Exporter 0
-      Test::Fatal 0
-      Test::More 0.88
-      Test::Requires 0
-      Try::Tiny 0
   Exporter-Lite-0.02
     pathname: M/MS/MSCHWERN/Exporter-Lite-0.02.tar.gz
     provides:
@@ -372,17 +246,6 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 6.11
       File::Spec 0
       IO::Dir 0
-  File-Slurp-9999.19
-    pathname: U/UR/URI/File-Slurp-9999.19.tar.gz
-    provides:
-      File::Slurp 9999.19
-      FileSlurp_12 9999.13
-    requirements:
-      Carp 0
-      Exporter 0
-      ExtUtils::MakeMaker 0
-      Fcntl 0
-      POSIX 0
   File-pushd-1.005
     pathname: D/DA/DAGOLDEN/File-pushd-1.005.tar.gz
     provides:
@@ -420,7 +283,7 @@ DISTRIBUTIONS
       File::Temp 0
       FindBin 0
       List::Util 0
-      Module::Build 0.4204
+      Module::Build 0.4205
       Symbol 0
       Test::More 0
       strict 0
@@ -611,24 +474,6 @@ DISTRIBUTIONS
       File::Temp 0
       Scalar::Util 0
       Test::More 0.88
-  IO-stringy-2.110
-    pathname: D/DS/DSKOLL/IO-stringy-2.110.tar.gz
-    provides:
-      Common undef
-      ExtUtils::TBone 1.1
-      IO::AtomicFile 2.110
-      IO::Clever 1.01
-      IO::InnerFile 2.110
-      IO::Lines 2.110
-      IO::Scalar 2.110
-      IO::ScalarArray 2.110
-      IO::Stringy 2.110
-      IO::Wrap 2.110
-      IO::WrapTie 2.110
-      IO::WrapTie::Master 2.110
-      IO::WrapTie::Slave 2.110
-    requirements:
-      ExtUtils::MakeMaker 0
   JSON-2.57
     pathname: M/MA/MAKAMAKA/JSON-2.57.tar.gz
     provides:
@@ -665,14 +510,6 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 6.52
       Test::More 0.82
       perl 5.00503
-  MRO-Compat-0.12
-    pathname: B/BO/BOBTFISH/MRO-Compat-0.12.tar.gz
-    provides:
-      MRO::Compat 0.12
-    requirements:
-      ExtUtils::MakeMaker 6.59
-      Test::More 0.47
-      perl 5.006
   Module-Build-Tiny-0.035
     pathname: L/LE/LEONT/Module-Build-Tiny-0.035.tar.gz
     provides:
@@ -695,34 +532,6 @@ DISTRIBUTIONS
       JSON::PP 2
       Pod::Man 0
       TAP::Harness::Env 0
-      perl 5.006
-      strict 0
-      warnings 0
-  Module-Implementation-0.06
-    pathname: D/DR/DROLSKY/Module-Implementation-0.06.tar.gz
-    provides:
-      Module::Implementation 0.06
-      T::Impl1 undef
-      T::Impl2 undef
-      T::ImplFails1 undef
-      T::ImplFails2 undef
-    requirements:
-      Carp 0
-      ExtUtils::MakeMaker 6.30
-      Module::Runtime 0.012
-      Test::Fatal 0
-      Test::More 0.88
-      Test::Requires 0
-      Try::Tiny 0
-      strict 0
-      warnings 0
-  Module-Runtime-0.013
-    pathname: Z/ZE/ZEFRAM/Module-Runtime-0.013.tar.gz
-    provides:
-      Module::Runtime 0.013
-    requirements:
-      Module::Build 0
-      Test::More 0
       perl 5.006
       strict 0
       warnings 0
@@ -838,246 +647,7 @@ DISTRIBUTIONS
       ojo undef
     requirements:
       ExtUtils::MakeMaker 0
-  Moose-2.0802
-    pathname: E/ET/ETHER/Moose-2.0802.tar.gz
-    provides:
-      Bar undef
-      Bar7::Meta::Trait undef
-      Bar7::Meta::Trait2 undef
-      BinaryTree 0.02
-      Class::MOP 2.0802
-      Class::MOP::Attribute 2.0802
-      Class::MOP::Class 2.0802
-      Class::MOP::Class::Immutable::Trait 2.0802
-      Class::MOP::Deprecated 2.0802
-      Class::MOP::Instance 2.0802
-      Class::MOP::Method 2.0802
-      Class::MOP::Method::Accessor 2.0802
-      Class::MOP::Method::Constructor 2.0802
-      Class::MOP::Method::Generated 2.0802
-      Class::MOP::Method::Inlined 2.0802
-      Class::MOP::Method::Meta 2.0802
-      Class::MOP::Method::Overload 2.0802
-      Class::MOP::Method::Wrapped 2.0802
-      Class::MOP::MiniTrait 2.0802
-      Class::MOP::Mixin 2.0802
-      Class::MOP::Mixin::AttributeCore 2.0802
-      Class::MOP::Mixin::HasAttributes 2.0802
-      Class::MOP::Mixin::HasMethods 2.0802
-      Class::MOP::Module 2.0802
-      Class::MOP::Object 2.0802
-      Class::MOP::Package 2.0802
-      Foo undef
-      MMHelper undef
-      MY undef
-      Moose 2.0802
-      Moose::Cookbook::Legacy::Debugging_BaseClassReplacement 2.0802
-      Moose::Cookbook::Meta::Labeled_AttributeMetaclass 2.0802
-      Moose::Deprecated 2.0802
-      Moose::Error::Confess 2.0802
-      Moose::Error::Croak 2.0802
-      Moose::Error::Default 2.0802
-      Moose::Exporter 2.0802
-      Moose::Meta::Attribute 2.0802
-      Moose::Meta::Attribute::Custom::Bar undef
-      Moose::Meta::Attribute::Custom::Foo undef
-      Moose::Meta::Attribute::Custom::Moose 2.0802
-      Moose::Meta::Attribute::Custom::Trait::Bar undef
-      Moose::Meta::Attribute::Custom::Trait::Foo undef
-      Moose::Meta::Attribute::Native 2.0802
-      Moose::Meta::Attribute::Native::Trait 2.0802
-      Moose::Meta::Attribute::Native::Trait::Array 2.0802
-      Moose::Meta::Attribute::Native::Trait::Bool 2.0802
-      Moose::Meta::Attribute::Native::Trait::Code 2.0802
-      Moose::Meta::Attribute::Native::Trait::Counter 2.0802
-      Moose::Meta::Attribute::Native::Trait::Hash 2.0802
-      Moose::Meta::Attribute::Native::Trait::Number 2.0802
-      Moose::Meta::Attribute::Native::Trait::String 2.0802
-      Moose::Meta::Class 2.0802
-      Moose::Meta::Class::Immutable::Trait 2.0802
-      Moose::Meta::Instance 2.0802
-      Moose::Meta::Method 2.0802
-      Moose::Meta::Method::Accessor 2.0802
-      Moose::Meta::Method::Accessor::Native 2.0802
-      Moose::Meta::Method::Accessor::Native::Array 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::Writer 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::accessor 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::clear 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::count 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::delete 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::elements 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::first 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::first_index 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::get 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::grep 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::insert 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::is_empty 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::join 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::map 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::natatime 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::pop 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::push 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::reduce 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::set 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::shallow_clone 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::shift 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::shuffle 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::sort 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::sort_in_place 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::splice 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::uniq 2.0802
-      Moose::Meta::Method::Accessor::Native::Array::unshift 2.0802
-      Moose::Meta::Method::Accessor::Native::Bool::not 2.0802
-      Moose::Meta::Method::Accessor::Native::Bool::set 2.0802
-      Moose::Meta::Method::Accessor::Native::Bool::toggle 2.0802
-      Moose::Meta::Method::Accessor::Native::Bool::unset 2.0802
-      Moose::Meta::Method::Accessor::Native::Code::execute 2.0802
-      Moose::Meta::Method::Accessor::Native::Code::execute_method 2.0802
-      Moose::Meta::Method::Accessor::Native::Collection 2.0802
-      Moose::Meta::Method::Accessor::Native::Counter::Writer 2.0802
-      Moose::Meta::Method::Accessor::Native::Counter::dec 2.0802
-      Moose::Meta::Method::Accessor::Native::Counter::inc 2.0802
-      Moose::Meta::Method::Accessor::Native::Counter::reset 2.0802
-      Moose::Meta::Method::Accessor::Native::Counter::set 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::Writer 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::accessor 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::clear 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::count 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::defined 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::delete 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::elements 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::exists 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::get 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::is_empty 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::keys 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::kv 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::set 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::shallow_clone 2.0802
-      Moose::Meta::Method::Accessor::Native::Hash::values 2.0802
-      Moose::Meta::Method::Accessor::Native::Number::abs 2.0802
-      Moose::Meta::Method::Accessor::Native::Number::add 2.0802
-      Moose::Meta::Method::Accessor::Native::Number::div 2.0802
-      Moose::Meta::Method::Accessor::Native::Number::mod 2.0802
-      Moose::Meta::Method::Accessor::Native::Number::mul 2.0802
-      Moose::Meta::Method::Accessor::Native::Number::set 2.0802
-      Moose::Meta::Method::Accessor::Native::Number::sub 2.0802
-      Moose::Meta::Method::Accessor::Native::Reader 2.0802
-      Moose::Meta::Method::Accessor::Native::String::append 2.0802
-      Moose::Meta::Method::Accessor::Native::String::chomp 2.0802
-      Moose::Meta::Method::Accessor::Native::String::chop 2.0802
-      Moose::Meta::Method::Accessor::Native::String::clear 2.0802
-      Moose::Meta::Method::Accessor::Native::String::inc 2.0802
-      Moose::Meta::Method::Accessor::Native::String::length 2.0802
-      Moose::Meta::Method::Accessor::Native::String::match 2.0802
-      Moose::Meta::Method::Accessor::Native::String::prepend 2.0802
-      Moose::Meta::Method::Accessor::Native::String::replace 2.0802
-      Moose::Meta::Method::Accessor::Native::String::substr 2.0802
-      Moose::Meta::Method::Accessor::Native::Writer 2.0802
-      Moose::Meta::Method::Augmented 2.0802
-      Moose::Meta::Method::Constructor 2.0802
-      Moose::Meta::Method::Delegation 2.0802
-      Moose::Meta::Method::Destructor 2.0802
-      Moose::Meta::Method::Meta 2.0802
-      Moose::Meta::Method::Overridden 2.0802
-      Moose::Meta::Mixin::AttributeCore 2.0802
-      Moose::Meta::Object::Trait 2.0802
-      Moose::Meta::Role 2.0802
-      Moose::Meta::Role::Application 2.0802
-      Moose::Meta::Role::Application::RoleSummation 2.0802
-      Moose::Meta::Role::Application::ToClass 2.0802
-      Moose::Meta::Role::Application::ToInstance 2.0802
-      Moose::Meta::Role::Application::ToRole 2.0802
-      Moose::Meta::Role::Attribute 2.0802
-      Moose::Meta::Role::Composite 2.0802
-      Moose::Meta::Role::Method 2.0802
-      Moose::Meta::Role::Method::Conflicting 2.0802
-      Moose::Meta::Role::Method::Required 2.0802
-      Moose::Meta::TypeCoercion 2.0802
-      Moose::Meta::TypeCoercion::Union 2.0802
-      Moose::Meta::TypeConstraint 2.0802
-      Moose::Meta::TypeConstraint::Class 2.0802
-      Moose::Meta::TypeConstraint::DuckType 2.0802
-      Moose::Meta::TypeConstraint::Enum 2.0802
-      Moose::Meta::TypeConstraint::Parameterizable 2.0802
-      Moose::Meta::TypeConstraint::Parameterized 2.0802
-      Moose::Meta::TypeConstraint::Registry 2.0802
-      Moose::Meta::TypeConstraint::Role 2.0802
-      Moose::Meta::TypeConstraint::Union 2.0802
-      Moose::Object 2.0802
-      Moose::Role 2.0802
-      Moose::Util 2.0802
-      Moose::Util::MetaRole 2.0802
-      Moose::Util::TypeConstraints 2.0802
-      Moose::Util::TypeConstraints::Builtins 2.0802
-      My::Bar undef
-      My::Content undef
-      My::Extract undef
-      My::Output undef
-      My::Trait::Bar undef
-      MyExporter undef
-      MyInline undef
-      MyMetaClass undef
-      MyMetaClass::Attribute undef
-      MyMetaClass::Instance undef
-      MyMetaClass::Method undef
-      MyMetaClass::Random undef
-      MyMetaclassRole undef
-      MyMooseA undef
-      MyMooseB undef
-      MyMooseObject undef
-      NoInlineAccessor undef
-      NoInlineAttribute undef
-      Role::Child undef
-      Role::Interface undef
-      Role::Parent undef
-      SyntaxError undef
-      Test::Moose 2.0802
-      inc::CheckDelta undef
-      inc::Clean undef
-      inc::ExtractInlineTests undef
-      inc::GitUpToDate undef
-      inc::MakeMaker undef
-      inc::RequireAuthorDeps undef
-      inc::TestRelease undef
-      metaclass 2.0802
-      oose 2.0802
-    requirements:
-      Carp 1.22
-      Class::Load 0.09
-      Class::Load::XS 0.01
-      Data::OptList 0.107
-      Devel::GlobalDestruction 0
-      Dist::CheckConflicts 0.02
-      Eval::Closure 0.04
-      ExtUtils::MakeMaker 6.30
-      List::MoreUtils 0.28
-      MRO::Compat 0.05
-      Package::DeprecationManager 0.11
-      Package::Stash 0.32
-      Package::Stash::XS 0.24
-      Params::Util 1.00
-      Scalar::Util 1.19
-      Sub::Exporter 0.980
-      Sub::Name 0.05
-      Task::Weaken 0
-      Test::Fatal 0.001
-      Test::More 0.88
-      Test::Requires 0.05
-      Try::Tiny 0.02
-  MooseX-NonMoose-0.22
-    pathname: D/DO/DOY/MooseX-NonMoose-0.22.tar.gz
-    provides:
-      MooseX::NonMoose 0.22
-      MooseX::NonMoose::InsideOut 0.22
-      MooseX::NonMoose::Meta::Role::Class 0.22
-      MooseX::NonMoose::Meta::Role::Constructor 0.22
-    requirements:
-      ExtUtils::MakeMaker 6.30
-      List::MoreUtils 0
-      Moose 1.15
-      Test::Fatal 0
-      Test::More 0.88
+      perl 5.010001
   Net-HTTP-6.06
     pathname: G/GA/GAAS/Net-HTTP-6.06.tar.gz
     provides:
@@ -1149,79 +719,6 @@ DISTRIBUTIONS
       POSIX 0
       Time::Local 0
       perl 5.008004
-  Package-DeprecationManager-0.13
-    pathname: D/DR/DROLSKY/Package-DeprecationManager-0.13.tar.gz
-    provides:
-      Package::DeprecationManager 0.13
-    requirements:
-      Carp 0
-      ExtUtils::MakeMaker 6.30
-      List::MoreUtils 0
-      Params::Util 0
-      Sub::Install 0
-      Test::Fatal 0
-      Test::More 0.88
-      Test::Requires 0
-      strict 0
-      warnings 0
-  Package-Stash-0.34
-    pathname: D/DO/DOY/Package-Stash-0.34.tar.gz
-    provides:
-      CompileTime undef
-      Package::Stash 0.34
-      Package::Stash::PP 0.34
-      inc::DistMeta undef
-      inc::MMPackageStash undef
-    requirements:
-      B 0
-      Carp 0
-      Dist::CheckConflicts 0.02
-      ExtUtils::MakeMaker 6.30
-      File::Find 0
-      File::Temp 0
-      Module::Implementation 0.06
-      Package::DeprecationManager 0
-      Package::Stash::XS 0.26
-      Scalar::Util 0
-      Symbol 0
-      Test::Fatal 0
-      Test::More 0.88
-      Test::Requires 0
-      base 0
-      constant 0
-      strict 0
-      warnings 0
-  Package-Stash-XS-0.26
-    pathname: D/DO/DOY/Package-Stash-XS-0.26.tar.gz
-    provides:
-      CompileTime undef
-      Package::Stash::XS 0.26
-    requirements:
-      B 0
-      ExtUtils::MakeMaker 6.30
-      File::Find 0
-      File::Temp 0
-      Scalar::Util 0
-      Symbol 0
-      Test::Fatal 0
-      Test::More 0.88
-      Test::Requires 0
-      XSLoader 0
-      base 0
-      constant 0
-      strict 0
-      warnings 0
-  Params-Util-1.07
-    pathname: A/AD/ADAMK/Params-Util-1.07.tar.gz
-    provides:
-      Params::Util 1.07
-    requirements:
-      ExtUtils::CBuilder 0.27
-      ExtUtils::MakeMaker 6.52
-      File::Spec 0.80
-      Scalar::Util 1.18
-      Test::More 0.42
-      perl 5.00503
   Path-Tiny-0.017
     pathname: D/DA/DAGOLDEN/Path-Tiny-0.017.tar.gz
     provides:
@@ -1418,54 +915,6 @@ DISTRIBUTIONS
       Stream::Buffered::PerlIO undef
     requirements:
       ExtUtils::MakeMaker 6.36
-  Sub-Exporter-0.985
-    pathname: R/RJ/RJBS/Sub-Exporter-0.985.tar.gz
-    provides:
-      Sub::Exporter 0.985
-      Sub::Exporter::Util 0.985
-      Test::SubExporter::DashSetup undef
-      Test::SubExporter::Faux undef
-      Test::SubExporter::GroupGen undef
-      Test::SubExporter::GroupGenSubclass undef
-      Test::SubExporter::ObjGen undef
-      Test::SubExporter::ObjGen::Obj undef
-      Test::SubExporter::s_e undef
-    requirements:
-      Carp 0
-      Data::OptList 0.100
-      Exporter 0
-      ExtUtils::MakeMaker 6.30
-      File::Find 0
-      File::Temp 0
-      Params::Util 0.14
-      Sub::Install 0.92
-      Test::More 0.96
-      base 0
-      overload 0
-      strict 0
-      subs 0
-      warnings 0
-  Sub-Exporter-Progressive-0.001010
-    pathname: F/FR/FREW/Sub-Exporter-Progressive-0.001010.tar.gz
-    provides:
-      Sub::Exporter::Progressive 0.001010
-    requirements:
-      ExtUtils::MakeMaker 0
-      Test::More 0.88
-  Sub-Install-0.926
-    pathname: R/RJ/RJBS/Sub-Install-0.926.tar.gz
-    provides:
-      Sub::Install 0.926
-    requirements:
-      ExtUtils::MakeMaker 0
-      Scalar::Util 0
-      Test::More 0
-  Sub-Name-0.05
-    pathname: F/FL/FLORA/Sub-Name-0.05.tar.gz
-    provides:
-      Sub::Name 0.05
-    requirements:
-      ExtUtils::MakeMaker 0
   Sub-Uplevel-0.24
     pathname: D/DA/DAGOLDEN/Sub-Uplevel-0.24.tar.gz
     provides:
@@ -1480,31 +929,6 @@ DISTRIBUTIONS
       constant 0
       strict 0
       warnings 0
-  TAP-Formatter-JUnit-0.09
-    pathname: G/GT/GTERMARS/TAP-Formatter-JUnit-0.09.tar.gz
-    provides:
-      TAP::Formatter::JUnit 0.09
-      TAP::Formatter::JUnit::Result undef
-      TAP::Formatter::JUnit::Session undef
-    requirements:
-      File::Slurp 0
-      IO::Scalar 0
-      Moose 0
-      MooseX::NonMoose 0
-      TAP::Harness 3.12
-      Test::Differences 0
-      Test::More 0
-      XML::Generator 0
-  Task-Weaken-1.04
-    pathname: A/AD/ADAMK/Task-Weaken-1.04.tar.gz
-    provides:
-      Task::Weaken 1.04
-    requirements:
-      ExtUtils::MakeMaker 6.42
-      File::Spec 0.80
-      Scalar::Util 1.14
-      Test::More 0.42
-      perl 5.005
   Test-Base-0.60
     pathname: I/IN/INGY/Test-Base-0.60.tar.gz
     provides:
@@ -1577,25 +1001,6 @@ DISTRIBUTIONS
       Test::More 0
       Test::NoWarnings 0.02
       Test::Tester 0.04
-  Test-Differences-0.61
-    pathname: O/OV/OVID/Test-Differences-0.61.tar.gz
-    provides:
-      Test::Differences 0.61
-    requirements:
-      Data::Dumper 2.126
-      Test::More 0
-      Text::Diff 0.35
-  Test-Exception-0.31
-    pathname: A/AD/ADIE/Test-Exception-0.31.tar.gz
-    provides:
-      Test::Exception 0.31
-    requirements:
-      Sub::Uplevel 0.18
-      Test::Builder 0.7
-      Test::Builder::Tester 1.07
-      Test::Harness 2.03
-      Test::More 0.7
-      Test::Simple 0.7
   Test-Fatal-0.010
     pathname: R/RJ/RJBS/Test-Fatal-0.010.tar.gz
     provides:
@@ -1749,31 +1154,12 @@ DISTRIBUTIONS
       Test::More 0
       Tree::DAG_Node 1.02
       perl 5.006
-  Text-Diff-1.41
-    pathname: O/OV/OVID/Text-Diff-1.41.tar.gz
+  Text-Markdown-Discount-0.13
+    pathname: S/SE/SEKIMURA/Text-Markdown-Discount-0.13.tar.gz
     provides:
-      Text::Diff 1.41
-      Text::Diff::Base 1.41
-      Text::Diff::Config 1.41
-      Text::Diff::Table 1.41
+      Text::Markdown::Discount 0.13
     requirements:
-      Algorithm::Diff 1.19
-      Exporter 0
       ExtUtils::MakeMaker 0
-  Text-Markdown-1.000031
-    pathname: B/BO/BOBTFISH/Text-Markdown-1.000031.tar.gz
-    provides:
-      Text::Markdown 1.000031
-    requirements:
-      Digest::MD5 0
-      Encode 0
-      ExtUtils::MakeMaker 6.42
-      FindBin 0
-      List::MoreUtils 0
-      Test::Differences 0
-      Test::Exception 0
-      Test::More 0.42
-      Text::Balanced 0
   Text-Markdown-Hoedown-1.01
     pathname: T/TO/TOKUHIROM/Text-Markdown-Hoedown-1.01.tar.gz
     provides:
@@ -1901,21 +1287,6 @@ DISTRIBUTIONS
       Fcntl 0
       URI 1.10
       perl 5.008001
-  XML-Generator-1.04
-    pathname: B/BH/BHOLZMAN/XML-Generator-1.04.tar.gz
-    provides:
-      XML::Generator 1.04
-      XML::Generator::DOM 0.2
-      XML::Generator::DOM::util 0.2
-      XML::Generator::cdata 1.04
-      XML::Generator::comment 1.04
-      XML::Generator::final 1.04
-      XML::Generator::overload 1.04
-      XML::Generator::pi 1.04
-      XML::Generator::pretty 1.04
-      XML::Generator::util 1.04
-    requirements:
-      ExtUtils::MakeMaker 0
   autodie-2.16
     pathname: P/PJ/PJF/autodie-2.16.tar.gz
     provides:

--- a/lib/Text/Md2Inao.pm
+++ b/lib/Text/Md2Inao.pm
@@ -64,6 +64,16 @@ sub prepare_text_for_markdown {
     ## Work Around: リストの後にコードブロックが続くとだめな問題 (issue #6)
     $text =~ s!([-*+] .*?)\n\n    !$1\n\n　\n\n    !g;
 
+    ## シンタックスハイライトの言語指定をもとに、`!!! cmd`の自動付加
+    $text =~ s/(```sh\n)([^!])/$1!!! cmd\n$2/g;
+    $text =~ s/(```shell-script\n)([^!])/$1!!! cmd\n$2/g;
+    $text =~ s/(```bash\n)([^!])/$1!!! cmd\n$2/g;
+    $text =~ s/(```zsh\n)([^!])/$1!!! cmd\n$2/g;
+    $text =~ s/(```bash session\n)([^!])/$1!!! cmd\n$2/g;
+    $text =~ s/(```console\n)([^!])/$1!!! cmd\n$2/g;
+    $text =~ s/(```posh\n)([^!])/$1!!! cmd\n$2/g;
+    $text =~ s/(```pwsh\n)([^!])/$1!!! cmd\n$2/g;
+
     ## PHP Markdown Extraスタイルのfootnoteの変換 (issue #120)
     $text = replace_markdown_extra_footnote($text);
 

--- a/t/30_indesign_basic_syntax.t
+++ b/t/30_indesign_basic_syntax.t
@@ -451,6 +451,47 @@ function bar(b) {
 <ParaStyle:コード黒地白文字>function bar(b) {
 <ParaStyle:コード黒地白文字>    alert(b); <CharStyle:コードコメント黒地白文字用> コメント <CharStyle:>
 <ParaStyle:コード黒地白文字>}
+
+=== pre for command, sh, no "!!! cmd"
+--- in md2inao
+```sh
+function bar(b) {
+    alert(b); (注:コメント)
+}
+```
+--- expected
+<ParaStyle:半行アキ>
+<ParaStyle:コード黒地白文字>function bar(b) {
+<ParaStyle:コード黒地白文字>    alert(b); <CharStyle:コードコメント黒地白文字用> コメント <CharStyle:>
+<ParaStyle:コード黒地白文字>}
+
+=== pre for command, shell-script, no "!!! cmd"
+--- in md2inao
+```shell-script
+function bar(b) {
+    alert(b); (注:コメント)
+}
+```
+--- expected
+<ParaStyle:半行アキ>
+<ParaStyle:コード黒地白文字>function bar(b) {
+<ParaStyle:コード黒地白文字>    alert(b); <CharStyle:コードコメント黒地白文字用> コメント <CharStyle:>
+<ParaStyle:コード黒地白文字>}
+
+=== pre for command, shell-script and "!!! cmd"
+--- in md2inao
+```shell-script
+!!! cmd
+function bar(b) {
+    alert(b); (注:コメント)
+}
+```
+--- expected
+<ParaStyle:半行アキ>
+<ParaStyle:コード黒地白文字>function bar(b) {
+<ParaStyle:コード黒地白文字>    alert(b); <CharStyle:コードコメント黒地白文字用> コメント <CharStyle:>
+<ParaStyle:コード黒地白文字>}
+
 === list
 --- in md2inao
     * ハイフンになる


### PR DESCRIPTION
シンタックスハイライトの言語指定をもとに、`!!! cmd`を自動で付加するようにしました。
シンタックスハイライトの言語指定と、`!!! cmd`の両方が指定されていても問題ありません。

@matobaa さんによるご変更です。