### PR TITLE
リード文の記法に対応する

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,16 @@ GitHub Flavored MarkdownのFenced code blocks記法の場合は、シェル系�
     本文
     </div>
 
+### リード文
+
+    <div class='lead'>
+    リード文
+    
+    リード文
+    
+    リード文
+    </div>
+
 ### 字下げ
 
 段落行頭の字下げは手動です。全角スペースを入れてください。

--- a/lib/Text/Md2Inao.pm
+++ b/lib/Text/Md2Inao.pm
@@ -42,6 +42,7 @@ has in_column      => (is => 'rw', isa => 'Bool');
 has in_code_block  => (is => 'rw', isa => 'Bool');
 has in_list        => (is => 'rw', isa => 'Bool');
 has in_quote_block => (is => 'rw', isa => 'Bool');
+has in_lead        => (is => 'rw', isa => 'Bool');
 
 has director => ( is => 'rw' );
 has builder  => ( is => 'rw' );
@@ -53,6 +54,7 @@ sub use_special_italic {
     return 1 if $self->in_code_block;
     return 1 if $self->in_list;
     return 1 if $self->in_quote_block;
+    return 1 if $self->in_lead;
     return;
 }
 

--- a/lib/Text/Md2Inao/Builder/InDesign.pm
+++ b/lib/Text/Md2Inao/Builder/InDesign.pm
@@ -223,6 +223,8 @@ case p => sub {
             $label = 'コラム本文';
         } elsif ($c->in_quote_block) {
             $label = '引用';
+        } elsif ($c->in_lead) {
+            $label = 'リード文';
         } else {
             $label = '本文';
         }
@@ -281,7 +283,7 @@ case div => sub {
     if ($h->attr('class') eq 'column') {
         $c->in_column(1);
 
-        # HTMLとして取得してcolumn自信のdivタグを削除
+        # HTMLとして取得してcolumn自身のdivタグを削除
         my $md = $h->as_HTML('');
         $md =~ s/^<div.+?>//;
         $md =~ s/<\/div>$//;
@@ -289,6 +291,17 @@ case div => sub {
         my $column = $c->parse_markdown($md);
         $c->in_column(0);
         return $column;
+    } elsif ($h->attr('class') eq 'lead') {
+        $c->in_lead(1);
+
+        # HTMLとして取得してlead自身のdivタグを削除
+        my $md = $h->as_HTML('');
+        $md =~ s/^<div.+?>//;
+        $md =~ s/<\/div>$//;
+
+        my $lead = $c->parse_markdown($md);
+        $c->in_lead(0);
+        return $lead;
     } else {
         return fallback_to_escaped_html($h);
     }

--- a/t/30_indesign_basic_syntax.t
+++ b/t/30_indesign_basic_syntax.t
@@ -138,6 +138,20 @@ _a-zA-Z0-9!"#$%&'()-=^@`[]{};+:*<>,./?_
 <ParaStyle:コラム内見出し>コラム内見出し
 <ParaStyle:コラム本文>　コラム内でも<CharStyle:太字>強調<CharStyle:>や<CharStyle:イタリック（変形斜体）>イタリックabc<CharStyle:>などが使えます。
 
+=== lead
+--- in md2inao
+<div class='lead'>
+リード文
+
+リード文
+
+リード文
+</div>
+--- expected
+<ParaStyle:リード文>リード文
+<ParaStyle:リード文>リード文
+<ParaStyle:リード文>リード文
+
 === list
 --- in md2inao
 * 通常の箇条書き


### PR DESCRIPTION
コラムのコードを参考に、リード文の記法（`<div class='lead'>`）に対応しました。